### PR TITLE
add default configs repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ we know about:
   Blue Box has the same, but in Ansible roles. The secret stuff is in
   an internal repo that provides variables to fill in content.
   
+* https://github.com/gfa/os-sample-configs
+  Default configs for nova, keystone, cinder, ceilometer and heat.
+  For Debian and Ubuntu versions of Havana, Icehouse and Juno.


### PR DESCRIPTION
hi, 
i would like to merge my default configs repo to osops org.  as i didn't found a button to join the organization i'm sending this pull request.

the pull request adds my defaults configs repo to example-configs README.md

